### PR TITLE
Fixed Take and Skip methods

### DIFF
--- a/Demo/Program.cs
+++ b/Demo/Program.cs
@@ -30,6 +30,8 @@ namespace Demo
 
 
                 var persons = Objects<Person>().Where(p => p.Name == "Roger").ToList();
+                var persons1 = Objects<Person>().Take(1).ToList();
+                var persons2 = Objects<Person>().Skip(1).ToList();
                 var person = Objects<Person>().FirstOrDefault(p => p.Name == "Roger");
                 var person2 = Objects<Person>().FirstOrDefault(p => p.Name != "Roger");
                 //Objects<Employee>().FirstOrDefault(p => p.Department.Company.Name == "Starcounter");
@@ -91,7 +93,8 @@ namespace Demo
                     for (int i = 0; i < 1000000; i++)
                     {
                         //this just traverses the linq expression tree, it doesnt touch the DB
-                        var res = Objects<Person>().FirstOrDefault(p => p.Name == "Roger");
+                        //var res = Objects<Person>().FirstOrDefault(p => p.Name == "Roger");
+                        var taken10 = Objects<Person>().Take(10).ToList();
                     }
                     sw.Stop();
                     return sw.Elapsed.ToString();

--- a/Demo/Program.cs
+++ b/Demo/Program.cs
@@ -93,8 +93,8 @@ namespace Demo
                     for (int i = 0; i < 1000000; i++)
                     {
                         //this just traverses the linq expression tree, it doesnt touch the DB
-                        //var res = Objects<Person>().FirstOrDefault(p => p.Name == "Roger");
-                        var taken10 = Objects<Person>().Take(10).ToList();
+                        var res = Objects<Person>().FirstOrDefault(p => p.Name == "Roger");
+                        //var taken10 = Objects<Person>().Take(10).ToList();
                     }
                     sw.Stop();
                     return sw.Elapsed.ToString();

--- a/Starcounter.Linq.Tests/LinqTests.cs
+++ b/Starcounter.Linq.Tests/LinqTests.cs
@@ -16,84 +16,84 @@ namespace Starcounter.Linq.Tests
         [Fact]
         public void ValueEquals()
         {
-            Assert.Equal("SELECT P FROM Starcounter.Linq.Tests.Person P WHERE ((P.Name = ?)) FETCH 1",
+            Assert.Equal("SELECT P FROM Starcounter.Linq.Tests.Person P WHERE ((P.Name = ?)) FETCH ?",
                 Sql(() => Objects<Person>().FirstOrDefault(p => p.Name == "XXX")));
         }
 
         [Fact]
         public void ValueNotEquals()
         {
-            Assert.Equal("SELECT P FROM Starcounter.Linq.Tests.Person P WHERE ((P.Name <> ?)) FETCH 1",
+            Assert.Equal("SELECT P FROM Starcounter.Linq.Tests.Person P WHERE ((P.Name <> ?)) FETCH ?",
                 Sql(() => Objects<Person>().FirstOrDefault(p => p.Name != "XXX")));
         }
 
         [Fact]
         public void ValueEqualsNot()
         {
-            Assert.Equal("SELECT P FROM Starcounter.Linq.Tests.Person P WHERE (NOT (P.Name = ?)) FETCH 1",
+            Assert.Equal("SELECT P FROM Starcounter.Linq.Tests.Person P WHERE (NOT (P.Name = ?)) FETCH ?",
                 Sql(() => Objects<Person>().FirstOrDefault(p => !(p.Name == "XXX"))));
         }
 
         [Fact]
         public void ValueGreaterThan()
         {
-            Assert.Equal("SELECT P FROM Starcounter.Linq.Tests.Person P WHERE ((P.Age > ?)) FETCH 1",
+            Assert.Equal("SELECT P FROM Starcounter.Linq.Tests.Person P WHERE ((P.Age > ?)) FETCH ?",
                 Sql(() => Objects<Person>().FirstOrDefault(p => p.Age > 123)));
         }
 
         [Fact]
         public void ValueGreaterOrEqualTo()
         {
-            Assert.Equal("SELECT P FROM Starcounter.Linq.Tests.Person P WHERE ((P.Age >= ?)) FETCH 1",
+            Assert.Equal("SELECT P FROM Starcounter.Linq.Tests.Person P WHERE ((P.Age >= ?)) FETCH ?",
                 Sql(() => Objects<Person>().FirstOrDefault(p => p.Age >= 123)));
         }
 
         [Fact]
         public void ValueLessThan()
         {
-            Assert.Equal("SELECT P FROM Starcounter.Linq.Tests.Person P WHERE ((P.Age < ?)) FETCH 1",
+            Assert.Equal("SELECT P FROM Starcounter.Linq.Tests.Person P WHERE ((P.Age < ?)) FETCH ?",
                 Sql(() => Objects<Person>().FirstOrDefault(p => p.Age < 123)));
         }
 
         [Fact]
         public void ValueLessOrEqualTo()
         {
-            Assert.Equal("SELECT P FROM Starcounter.Linq.Tests.Person P WHERE ((P.Age <= ?)) FETCH 1",
+            Assert.Equal("SELECT P FROM Starcounter.Linq.Tests.Person P WHERE ((P.Age <= ?)) FETCH ?",
                 Sql(() => Objects<Person>().FirstOrDefault(p => p.Age <= 123)));
         }
 
         [Fact]
         public void StringContains()
         {
-            Assert.Equal("SELECT P FROM Starcounter.Linq.Tests.Person P WHERE ((P.Name LIKE '%' || ? || '%')) FETCH 1",
+            Assert.Equal("SELECT P FROM Starcounter.Linq.Tests.Person P WHERE ((P.Name LIKE '%' || ? || '%')) FETCH ?",
                 Sql(() => Objects<Person>().FirstOrDefault(p => p.Name.Contains("XXX"))));
         }
 
         [Fact]
         public void StringStartsWith()
         {
-            Assert.Equal("SELECT P FROM Starcounter.Linq.Tests.Person P WHERE ((P.Name LIKE ? || '%')) FETCH 1",
+            Assert.Equal("SELECT P FROM Starcounter.Linq.Tests.Person P WHERE ((P.Name LIKE ? || '%')) FETCH ?",
                 Sql(() => Objects<Person>().FirstOrDefault(p => p.Name.StartsWith("XXX"))));
         }
 
         [Fact]
         public void StringEndsWith()
         {
-            Assert.Equal("SELECT P FROM Starcounter.Linq.Tests.Person P WHERE ((P.Name LIKE '%' || ?)) FETCH 1",
+            Assert.Equal("SELECT P FROM Starcounter.Linq.Tests.Person P WHERE ((P.Name LIKE '%' || ?)) FETCH ?",
                 Sql(() => Objects<Person>().FirstOrDefault(p => p.Name.EndsWith("XXX"))));
         }
 
         [Fact]
         public void TypeIs()
         {
-            Assert.Equal("SELECT P FROM Starcounter.Linq.Tests.Person P WHERE ((P IS Starcounter.Linq.Tests.Employee)) FETCH 1",
+            Assert.Equal("SELECT P FROM Starcounter.Linq.Tests.Person P WHERE ((P IS Starcounter.Linq.Tests.Employee)) FETCH ?",
                 Sql(() => Objects<Person>().FirstOrDefault(p => p is Employee)));
         }
 
         [Fact]
         public void TypeIsNot()
         {
-            Assert.Equal("SELECT P FROM Starcounter.Linq.Tests.Person P WHERE (NOT (P IS Starcounter.Linq.Tests.Employee)) FETCH 1",
+            Assert.Equal("SELECT P FROM Starcounter.Linq.Tests.Person P WHERE (NOT (P IS Starcounter.Linq.Tests.Employee)) FETCH ?",
                 Sql(() => Objects<Person>().FirstOrDefault(p => !(p is Employee))));
         }
     }

--- a/Starcounter.Linq.Tests/TakeTests.cs
+++ b/Starcounter.Linq.Tests/TakeTests.cs
@@ -10,14 +10,14 @@ namespace Starcounter.Linq.Tests
         [Fact]
         public void Take()
         {
-            Assert.Equal("SELECT P FROM Starcounter.Linq.Tests.Person P FETCH 10",
+            Assert.Equal("SELECT P FROM Starcounter.Linq.Tests.Person P FETCH ?",
                 Sql(() => Objects<Person>().Take(10)));
         }
 
         [Fact]
         public void Skip()
         {
-            Assert.Equal("SELECT P FROM Starcounter.Linq.Tests.Person P FETCH 10 OFFSET 20",
+            Assert.Equal("SELECT P FROM Starcounter.Linq.Tests.Person P FETCH ? OFFSET ?",
                 Sql(() => Objects<Person>().Skip(20).Take(10)));
         }
     }

--- a/src/QueryBuilder.cs
+++ b/src/QueryBuilder.cs
@@ -29,11 +29,11 @@ namespace Starcounter.Linq
 
         private List<object> Variables { get; } = new List<object>();
 
-        public string FetchPart { get; private set; }
-        public string OffsetPart { get; private set; }
+        public int FetchValue { get; private set; } = -1;
+        public int OffsetValue { get; private set; } = -1;
 
-        public void Fetch(int count) => FetchPart = " FETCH " + count;
-        public void Offset(int count) => OffsetPart = " OFFSET " + count;
+        public void Fetch(int count) => FetchValue = count;
+        public void Offset(int count) => OffsetValue = count;
 
         public void BeginWhereSection()
         {
@@ -97,14 +97,16 @@ namespace Starcounter.Linq
                 stringBuilder.Append(OrderBy);
             }
 
-            if (FetchPart != null)
+            if (FetchValue >= 0)
             {
-                stringBuilder.Append(FetchPart);
+                stringBuilder.Append(" FETCH ?");
+                Variables.Add(FetchValue);
             }
 
-            if (OffsetPart != null)
+            if (OffsetValue >= 0)
             {
-                stringBuilder.Append(OffsetPart);
+                stringBuilder.Append(" OFFSET ?");
+                Variables.Add(OffsetValue);
             }
 
             return stringBuilder.ToString();

--- a/src/QueryContext.cs
+++ b/src/QueryContext.cs
@@ -27,7 +27,7 @@ namespace Starcounter.Linq
             {
                 return Db.SQL<T>(sql, variables);
             }
-            else if (typeof(TResult).IsClass)
+            if (typeof(TResult).IsClass)
             {
                 return Db.SQL<TResult>(sql, variables);
             }


### PR DESCRIPTION
I've checked - this approach works faster than approach with `Db.SlowSql` and literals.