### PR TITLE
Throw exception when null value is passed to a complied query

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ people = query();
 
 ### NULL values
 
-Since comparisons with `null` values are translated to `IS NULL` form in SQL, there is no possibility to pass such values with parameters into compiled queries.
+Since comparisons with `null` values are translated to `IS NULL` form in SQL, there is no possibility to pass such values with parameters into compiled queries. Starcounter.Linq throws an exception in such cases.
 
 Example:
 
@@ -153,7 +153,7 @@ var withOfficeQuery = DbLinq.CompileQuery((notNullOffice) =>
                       DbLinq.Objects<Employee>().FirstOrDefault(p => p.Office == notNullOffice));
 
 // it does not work because the SQL query has been translated and IS NULL cannot be inserted
-employee1 = withOfficeQuery(null);
+employee1 = withOfficeQuery(null);  // ArgumentNullException will be thrown
 
 // that should be written in the following way
 employee1 = office == null ? withoutOfficeQuery() : withOfficeQuery(office);

--- a/src/Starcounter.Linq/CompiledQuery.cs
+++ b/src/Starcounter.Linq/CompiledQuery.cs
@@ -74,6 +74,10 @@ namespace Starcounter.Linq
 
         protected virtual TResult ExecuteCore<TResult>(CancellationToken cancellationToken, params object[] parameters)
         {
+            if (parameters.Any(x => x == null))
+            {
+                throw new ArgumentNullException(nameof(parameters), "Compiled query does not support null value as a parameter.");
+            }
             return (TResult)QueryExecutor.Execute<TResult>(SqlStatement, parameters, QueryResultMethod);
         }
 

--- a/test/Starcounter.Linq.QueryTests/Tests/FilteringTests.cs
+++ b/test/Starcounter.Linq.QueryTests/Tests/FilteringTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Xunit;
 using static Starcounter.Linq.DbLinq;
 
@@ -311,11 +312,13 @@ namespace Starcounter.Linq.QueryTests
         {
             Scheduling.RunTask(() =>
             {
-                Office office = null;
-                // this is incorrect, Compiled Query is not supported passing null with parameter (only inline, see FirstObjectEqualNull test)
-                var employee = CompileQuery((Office o) => Objects<Employee>().FirstOrDefault(p => p.Office != o))(office);
+                Employee employee = null;
 
-                Assert.Null(employee);  // because the built SQL was incorrect
+                // this is incorrect, Compiled Query is not supported passing null with parameter (only inline, see FirstObjectEqualNull test)
+                var query = CompileQuery((Office o) => Objects<Employee>().FirstOrDefault(p => p.Office != o));
+
+                Assert.Throws<ArgumentNullException>(() => employee = query(null));
+                Assert.Null(employee);
             }).Wait();
         }
 


### PR DESCRIPTION
By @joozek78's proposal for https://github.com/Starcounter/Starcounter.Linq/issues/62.
Approve if you agree with the solution.